### PR TITLE
feat: move @ngx-loading-bar/core to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Table of contents
 
 ```bash
   # if you use `@angular/common/http`
-  npm install @ngx-loading-bar/http-client --save
+  npm install @ngx-loading-bar/core @ngx-loading-bar/http-client --save
 
   # if you use `@angular/http`
-  npm install @ngx-loading-bar/http --save
+  npm install @ngx-loading-bar/core @ngx-loading-bar/http --save
 
   # if you use `@angular/router`
-  npm install @ngx-loading-bar/router --save
+  npm install @ngx-loading-bar/core @ngx-loading-bar/router --save
 
   # to manage loading-bar manually
   npm install @ngx-loading-bar/core --save

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -8,8 +8,7 @@
     "type": "git"
   },
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.7.1",
+  "peerDependencies": {
     "@ngx-loading-bar/core": "LOADING-BAR-VERSION"
   }
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -8,11 +8,8 @@
     "url": "https://github.com/aitboudad/ngx-loading-bar.git",
     "type": "git"
   },
-  "dependencies": {
-    "tslib": "^1.7.1",
-    "@ngx-loading-bar/core": "LOADING-BAR-VERSION"
-  },
   "peerDependencies": {
+    "@ngx-loading-bar/core": "LOADING-BAR-VERSION",
     "@angular/http": ">=7.0.0"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -8,11 +8,8 @@
     "url": "https://github.com/aitboudad/ngx-loading-bar.git",
     "type": "git"
   },
-  "dependencies": {
-    "tslib": "^1.7.1",
-    "@ngx-loading-bar/core": "LOADING-BAR-VERSION"
-  },
   "peerDependencies": {
+    "@ngx-loading-bar/core": "LOADING-BAR-VERSION",
     "@angular/router": ">=7.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: @ngx-loading-bar/core has been moved to peerDependencies which require
to install the dependency by yourself `npm install
@ngx-loading-bar/core`

Issues: fix #111