### PR TITLE
[WIP] Fix incompatibility with NGXS

### DIFF
--- a/demo/src/app/api.store.ts
+++ b/demo/src/app/api.store.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Action, State, StateContext } from '@ngxs/store';
+import { tap } from 'rxjs/operators';
+
+export namespace Api {
+  export class LoadResources {
+    static readonly type = '[API] Load Resources';
+  }
+}
+
+export interface ApiStateModel {
+  data: any;
+}
+
+@State<ApiStateModel>({
+  name: 'api',
+})
+@Injectable()
+export class ApiState {
+  constructor(private http: HttpClient) {}
+
+  @Action(Api.LoadResources)
+  loadResources(ctx: StateContext<ApiStateModel>) {
+    return this.http.get('https://jsonplaceholder.typicode.com/users').pipe(tap((data) => ctx.setState({ data })));
+  }
+}

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -82,5 +82,16 @@
         </div>
       </div>
     </div>
+
+    <div class="d-flex flex-wrap justify-content-center">
+      <div class="card m-2" style="width: 310px">
+        <div class="card-body">
+          <p class="card-text">Dispatching with NGXS</p>
+          <button class="btn btn-block btn-sm btn-info" (click)="dispatchRequest()" type="button" name="button">
+            Dispatch
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -13,7 +13,7 @@
 
     <div class="d-flex flex-wrap justify-content-center">
       <div class="card m-2" style="width: 310px">
-        <ngx-loading-bar fixed ref="http" color="#17a2b8"></ngx-loading-bar>
+        <ngx-loading-bar [fixed] ref="http" color="#17a2b8"></ngx-loading-bar>
         <div class="card-body">
           <h4 class="card-title text-center">@ngx-loading-bar/http</h4>
           <p class="card-text">Display loading-bar on http request</p>
@@ -24,7 +24,7 @@
       </div>
 
       <div class="card m-2" style="width: 310px">
-        <ngx-loading-bar fixed ref="router" color="#17a2b8"></ngx-loading-bar>
+        <ngx-loading-bar [fixed] ref="router" color="#17a2b8"></ngx-loading-bar>
         <div class="card-body">
           <h4 class="card-title text-center">@ngx-loading-bar/router</h4>
           <p class="card-text">Display loading-bar on route navigation</p>
@@ -52,7 +52,7 @@
 
     <div class="d-flex flex-wrap justify-content-center">
       <div class="card m-2" style="width: 310px">
-        <ngx-loading-bar fixed ref="default" color="#17a2b8"></ngx-loading-bar>
+        <ngx-loading-bar [fixed] ref="default" color="#17a2b8"></ngx-loading-bar>
         <div class="card-body">
           <h4 class="card-title text-center">@ngx-loading-bar/core</h4>
           <p class="card-text">Manage manually loading bar</p>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,6 +1,8 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { LoadingBarService } from '@ngx-loading-bar/core';
+import { Store } from '@ngxs/store';
+import { Api } from './api.store';
 
 @Component({
   selector: 'app-root',
@@ -8,7 +10,7 @@ import { LoadingBarService } from '@ngx-loading-bar/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
-  constructor(private httpClient: HttpClient, public loader: LoadingBarService) {}
+  constructor(private httpClient: HttpClient, public loader: LoadingBarService, private store: Store) {}
 
   startHttpRequest() {
     this.httpClient.get('https://jsonplaceholder.typicode.com/users').subscribe();
@@ -32,5 +34,9 @@ export class AppComponent {
 
   stop() {
     this.loader.useRef().stop();
+  }
+
+  dispatchRequest() {
+    this.store.dispatch(new Api.LoadResources());
   }
 }

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -8,6 +8,9 @@ import { LoadingBarHttpClientModule } from '@ngx-loading-bar/http-client';
 import { LoadingBarRouterModule } from '@ngx-loading-bar/router';
 import { AppComponent } from './app.component';
 import { HelloComponent } from './hello.component';
+import { NgxsModule } from '@ngxs/store';
+import { environment } from '../environments/environment';
+import { ApiState } from './api.store';
 
 @NgModule({
   declarations: [AppComponent, HelloComponent],
@@ -24,6 +27,8 @@ import { HelloComponent } from './hello.component';
 
     LoadingBarHttpClientModule,
     LoadingBarRouterModule,
+
+    NgxsModule.forRoot([ApiState], { developmentMode: !environment.production }),
   ],
   bootstrap: [AppComponent],
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,6 +2676,14 @@
         }
       }
     },
+    "@ngxs/store": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@ngxs/store/-/store-3.7.1.tgz",
+      "integrity": "sha512-Qg4rkF8XoIg/E2SGUfBbr4JmR8ZbRfeg1X++fF0HJymK1PtbIxtEXQXm7VTH0+GSmYDCwPJb8Im9dZHGZWF5ww==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "@rollup/plugin-commonjs": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@angular/platform-browser": "^9.0.4",
     "@angular/platform-browser-dynamic": "^9.0.4",
     "@angular/router": "^9.0.4",
+    "@ngxs/store": "^3.7.1",
     "bootstrap": "^4.5.3",
     "core-js": "^3.6.4",
     "rxjs": "^6.5.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,8 @@
       "@ngx-loading-bar/*": ["packages/*/src/public_api"]
     }
   },
+  "angularCompilerOptions": {
+    "strictTemplates": true
+  },
   "exclude": ["dist/**/*", "node_modules/**/*"]
 }


### PR DESCRIPTION
I'm trying to debug the issue which breaks the loading bar when used with [NGXS](https://www.ngxs.io) as demonstrated [here](https://stackblitz.com/edit/loading-bar-ngxs). For now, I have set up the dev environment with NGXS and ngx-loading-bar.

Issues I'm facing:

- The HTTP interceptor seems to be working correctly: the observable completes correctly, even when called from an NGXS action, but the loading bar neither starts nor completes.

This PR would close #184.